### PR TITLE
Add tests and function for nav bar links

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,17 @@
     <%= javascript_pack_tag 'application' %>
   </head>
 
+  <header>
+    <div class="nav-bar">
+      <p>
+        <%= link_to "Home", "/" %>
+        <%= link_to "Locations", locations_path %>
+        <%= link_to "Clinicians", clinicians_path %>
+        <%= link_to "Documents"  %>
+      </p>
+    </div>
+  </header>
+
   <body>
     <%= yield %>
   </body>

--- a/spec/features/layout/nav_bar_spec.rb
+++ b/spec/features/layout/nav_bar_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe 'Nav bar links' do
+  describe 'when I visit any page' do
+    it 'shows a link to the locations, clinicians documents and home' do
+      visit '/'
+
+      expect(page).to have_link("Home")
+      expect(page).to have_link("Locations")
+      expect(page).to have_link("Clinicians")
+      expect(page).to have_link("Documents")
+    end
+
+    it 'shows a link to the locations, clinicians documents and home' do
+      visit clinicians_path
+
+      expect(page).to have_link("Home")
+      expect(page).to have_link("Locations")
+      expect(page).to have_link("Clinicians")
+      expect(page).to have_link("Documents")
+    end
+
+    it 'shows a link to the locations, clinicians documents and home' do
+      visit locations_path
+
+      expect(page).to have_link("Home")
+      expect(page).to have_link("Locations")
+      expect(page).to have_link("Clinicians")
+      expect(page).to have_link("Documents")
+    end
+
+    xit 'shows a link to the locations, clinicians documents and home' do
+      visit documents_path
+
+      expect(page).to have_link("Home")
+      expect(page).to have_link("Locations")
+      expect(page).to have_link("Clinicians")
+      expect(page).to have_link("Documents")
+    end
+
+  end
+end

--- a/spec/features/welcome/welcome_spec.rb
+++ b/spec/features/welcome/welcome_spec.rb
@@ -6,8 +6,10 @@ RSpec.describe 'Welcome page' do
       it 'has links to the clinician and location index pages' do
         visit '/'
 
-        expect(page).to have_link('Clinicians')
-        expect(page).to have_link('Locations')
+        within("#links") do
+          expect(page).to have_link('Clinicians')
+          expect(page).to have_link('Locations')
+        end
       end
     end
 
@@ -15,9 +17,10 @@ RSpec.describe 'Welcome page' do
       it 'takes me to the clinician index page' do
         visit '/'
   
-        click_link('Clinicians')
-  
-        expect(current_path).to eq(clinicians_path)
+        within("#links") do
+          click_link('Clinicians')
+          expect(current_path).to eq(clinicians_path)
+        end
       end
     end
 
@@ -25,9 +28,10 @@ RSpec.describe 'Welcome page' do
       it 'takes me to the location index page' do
         visit '/'
   
-        click_link('Locations')
-  
-        expect(current_path).to eq(locations_path)
+        within("#links") do
+          click_link('Locations')
+          expect(current_path).to eq(locations_path)
+        end
       end
     end
   end


### PR DESCRIPTION
Add tests for nav bar links
Add links for home, locations, clinicians, and documents
Update tests for welcome page
One test skipped. The test to find the nav bar links on the documents page
98.06% coverage, due to skipped test